### PR TITLE
Branch pom.xml for Alfresco 4.2.f

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>org.alfresco.maven</groupId>
         <artifactId>alfresco-sdk-parent</artifactId>
-        <version>2.1.0</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
 
     <!-- 
@@ -22,8 +22,8 @@
        -->
     <properties>
         <!-- The following are default values for data location and Alfresco version.
-             Uncomment if you need to change
-        <alfresco.version>${alfresco.community.default.version}</alfresco.version> -->
+             Uncomment if you need to change -->
+        <alfresco.version>4.2.f</alfresco.version>
 
         <!-- This control the root logging level for all apps uncomment and change, defaults to WARN
             <app.log.root.level>WARN</app.log.root.level>
@@ -66,6 +66,7 @@
 
     <!-- Following dependencies are needed for compiling Java code in src/main/java;  -->
     <dependencies>
+             <!--
         <dependency>
             <groupId>${alfresco.groupId}</groupId>
             <artifactId>share</artifactId>
@@ -78,6 +79,7 @@
             <artifactId>spring-surf-api</artifactId>
             <scope>provided</scope>
         </dependency>
+        -->
     </dependencies>
 
     <build>


### PR DESCRIPTION
The provided root pom.xml does not compile or work in a 4.2.f environment without the enclosed changes.

They are:
1. Change the SDK version from 2.1.0 to 1.2.0.
2. Add the alfresco.version to properties.
3. Comment out Dependencies after line 69, including spring-surf-api

This should be an independent branch, for Alfresco 4.2.f, since the original version works with Alfresco 5.
